### PR TITLE
Allow user to override style settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ exports.decorateConfig = config => {
       background-color: ${colors.lightBlack} !important;
     }
   `;
+
   const termCSS = `
     ${config.termCSS || ''}
 
@@ -104,15 +105,22 @@ exports.decorateConfig = config => {
     }
   `;
 
-  config.backgroundColor = config.backgroundColor || colors.black;
-  config.foregroundColor = config.foregroundColor || colors.white;
-  config.borderColor = config.borderColor || colors.black;
-  config.cursorAccentColor = config.cursorAccentColor || colors.black;
-  config.cursorColor = config.cursorColor || colors.red;
-  config.selectionColor = config.selectionColor || colors.transparentRed;
-  config.padding = config.padding || '12px 24px';
+  const backgroundColor = colors.black;
+  const foregroundColor = colors.white;
+  const borderColor = colors.black;
+  const cursorAccentColor = colors.black;
+  const cursorColor = colors.red;
+  const selectionColor = colors.transparentRed;
+  const padding = '12px 24px';
 
   return Object.assign({}, config, {
+    backgroundColor,
+    foregroundColor,
+    borderColor,
+    cursorColor,
+    cursorAccentColor,
+    selectionColor,
+    padding,
     colors,
     termCSS,
     css

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ exports.decorateConfig = config => {
   };
 
   const css = `
+    ${config.css || ''}
+  
     .hyper_main {
       // border: none !important;
     }
@@ -76,6 +78,8 @@ exports.decorateConfig = config => {
     }
   `;
   const termCSS = `
+    ${config.termCSS || ''}
+
     .xterm-text-layer a {
       text-decoration: underline !important;
       color: ${colors.yellow} !important;
@@ -100,13 +104,13 @@ exports.decorateConfig = config => {
     }
   `;
 
-  config.backgroundColor = colors.black;
-  config.foregroundColor = colors.white;
-  config.borderColor = colors.black;
-  config.cursorAccentColor = colors.black;
-  config.cursorColor = colors.red;
-  config.selectionColor = colors.transparentRed;
-  config.padding = '12px 24px';
+  config.backgroundColor = config.backgroundColor || colors.black;
+  config.foregroundColor = config.foregroundColor || colors.white;
+  config.borderColor = config.borderColor || colors.black;
+  config.cursorAccentColor = config.cursorAccentColor || colors.black;
+  config.cursorColor = config.cursorColor || colors.red;
+  config.selectionColor = config.selectionColor || colors.transparentRed;
+  config.padding = config.padding || '12px 24px';
 
   return Object.assign({}, config, {
     colors,


### PR DESCRIPTION
Thanks for this! I just discovered Horizon and having my Hyper & VSCode themes match is always nice.

I noticed, however, that I couldn't update the CSS and some terminal settings because the config was overly aggressive -- I like to set it so inactive panes are faded out a bit but my custom CSS wasn't taking hold. I've updated the config a bit to allow user CSS. It also stops the theme from mutating the config object directly (it might be a good idea to allow users to override the settings at the end as well, especially the padding setting).